### PR TITLE
Fix for runvectors.jl

### DIFF
--- a/src/run/runvectors.jl
+++ b/src/run/runvectors.jl
@@ -38,7 +38,7 @@ function basic_running(window_fn::Function,
     nvalues = nrolled(n, window_span)
     ntapers = n - nvalues
 
-    rettype  = rts(window_fn, (Vector{T},))
+    rettype  = rts(window_fn, (Vector{T},Vector{T}))
     results = Vector{rettype}(undef, n)
 
     @inbounds for idx in 1:ntapers

--- a/src/run/runvectors_weighted.jl
+++ b/src/run/runvectors_weighted.jl
@@ -49,7 +49,7 @@ function basic_running(window_fn::Function,
     nvalues = nrolled(n, window_span)
     ntapers = n - nvalues
 
-    rettype  = rts(window_fn, (Vector{T},))
+    rettype  = rts(window_fn, (Vector{T},Vector{T}))
     results = Vector{rettype}(undef, n)
 
     @inbounds for idx in 1:ntapers


### PR DESCRIPTION
Fix the issue when function needs two data
```
rettype = rts(window_fn, (Vector{T},))
```