### PR TITLE
Remove unnecessary dependencies and bump version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,13 @@ uuid = "b0e4dd01-7b14-53d8-9b45-175a3e362653"
 repo = "https://github.com/JeffreySarnoff/RollingFunctions.jl.git"
 authors = ["Jeffrey Sarnoff and other contributors"]
 license = "MIT"
-version = "v0.8.0"
+version = "v0.8.1"
 
 [deps]
 KahanSummation = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
-AccurateArithmetic = "22286c92-06ac-501d-9306-4abd417d9753"
-Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -24,11 +20,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
-FastBroadcast = "0.2, 0.3, 0.4"
 KahanSummation = "0.3, 0.4"
 Statistics = "1.7"
 StatsBase = "0.33, 0.34, 0.35, 0.36"
-LoopVectorization = "0.12, 0.13, 0.14"
-AccurateArithmetic = "0.3.8, 0.3.9, 0.3.10"
-Tables = "1.10"
 julia = "1.8"

--- a/src/RollingFunctions.jl
+++ b/src/RollingFunctions.jl
@@ -32,15 +32,6 @@ using StatsBase:  kurtosis, mad, sem, skewness, variation,
                   FrequencyWeights, AnalyticWeights, ProbabilityWeights
 
 using KahanSummation: sum_kbn
-using AccurateArithmetic: sum_oro
-
-using LoopVectorization
-
-for T in (:Int8, :Int16, :Int32, :Int64, :Int128,
-          :UInt8, :UInt16, :UInt32, :UInt64, :UInt128,
-          :Float16, :Float32, :Float64)
-  @eval LoopVectorization.check_args(x::Union{Missing,$T}) = true
-end
 
 const Sequence = Union{Vec, Tup} where {N, T, Vec<:AbstractVector{T}, Tup<:NTuple{N,T}}
 


### PR DESCRIPTION
I removed the dependencies that were obviously not used. 

Resolves https://github.com/JeffreySarnoff/RollingFunctions.jl/issues/50

Would be great if 0.8.1 could be released soon.